### PR TITLE
correccion en reseteo de contraseñas para usuarios sin permisos

### DIFF
--- a/API/Controllers/UserController.cs
+++ b/API/Controllers/UserController.cs
@@ -131,5 +131,26 @@ namespace API.Controllers
                 return BadRequest(new { error = ex.Message });
             }
         }
+
+        [HttpPost("resetmypassword")]
+        public IActionResult ResetMyPassword([FromBody] ResetMyPasswordRequest request)
+        {
+            try
+            {
+                UserResponse? user = _facade.Authenticate(request.Username, request.OldPassword);
+                if (user == null)
+                    return Unauthorized(new { error = "Credenciales inválidas" });
+
+                return Ok(new { message = "Contraseña restablecida correctamente:", password = _facade.ResetPassword(user.Id, request.NewPassword) });
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(FormatearError(ex));
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new { error = ex.Message });
+            }
+        }
     }
 }

--- a/BusinessLogic/DTOs/DTOsUser/ResetMyPasswordRequest.cs
+++ b/BusinessLogic/DTOs/DTOsUser/ResetMyPasswordRequest.cs
@@ -1,0 +1,9 @@
+﻿namespace BusinessLogic.DTOs.DTOsUser
+{
+    public class ResetMyPasswordRequest
+    {
+        public string Username { get; set; }
+        public string OldPassword { get; set; } = string.Empty;
+        public string NewPassword { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
Cambio de endpoint para reseteo de contraseña solicitados por usuarios sin permisos edit users:
post {{baseUrl}}/api/Users/resetmypassword
{
"username": "admin",
"oldpassword": "Pass.123",
"newpassword": "Pass.12345"
}
ok
{
"message": "Contraseña restablecida correctamente:",
"password": "Pass.12345"
}
autenticacion incorrecta:
{
"error": "Credenciales inválidas"
}
password error:
{
"campo": "Password",
"error": "La contraseña debe tener entre 8 y 30 caracteres, incluyendo al menos una mayúscula, una minúscula, un número y un carácter especial."
}